### PR TITLE
NEW: ADD NEW FIELD FOR LIST OF MEDICAMENTS IN THE CONSULTATION PAGE.

### DIFF
--- a/htdocs/cabinetmed/admin/admin.php
+++ b/htdocs/cabinetmed/admin/admin.php
@@ -86,6 +86,8 @@ if ($action == 'update') {
 		$res=dolibarr_set_const($db, 'CABINETMED_DELAY_TO_LOCK_RECORD', GETPOST("CABINETMED_DELAY_TO_LOCK_RECORD") ? 0 : 1, 'texte', 0, '', $conf->entity);
 	}
 
+	$res=dolibarr_set_const($db, 'CABINETMED_SHOW_MEDICAMENTS_LIST', GETPOST("CABINETMED_SHOW_MEDICAMENTS_LIST"), 'texte', 0, '', $conf->entity);
+
 	if ($res == 1) {
 		$mesg=$langs->trans("RecordModifiedSuccessfully");
 	} else {
@@ -170,6 +172,10 @@ print '</tr>';
 
 print '<tr class="oddeven"><td>'.$langs->trans("CABINETMED_DELAY_TO_LOCK_RECORD").'</td>';
 print '<td><input type="number" class="maxwidth50 right" min="0" name="CABINETMED_DELAY_TO_LOCK_RECORD" value="'.getDolGlobalInt('CABINETMED_DELAY_TO_LOCK_RECORD').'"></td>';
+print '</tr>';
+
+print '<tr class="oddeven"><td>'.$langs->trans("CABINETMED_SHOW_MEDICAMENTS_LIST").'</td>';
+print '<td>'.$form->selectyesno('CABINETMED_SHOW_MEDICAMENTS_LIST', getDolGlobalString('CABINETMED_SHOW_MEDICAMENTS_LIST'), 1).'</td>';
 print '</tr>';
 
 print '</table>';

--- a/htdocs/cabinetmed/consultations.php
+++ b/htdocs/cabinetmed/consultations.php
@@ -755,9 +755,20 @@ if (! ($socid > 0)) {
                     var box = jQuery("#examenprescrit");
                     u=box.val() + (box.val() != \'\' ? "\n" : \'\') + t;
                     box.val(u); box.html(u);
-                    jQuery("#addexambox .ui-autocomplete-input").val("");
+					jQuery("#addexambox .ui-autocomplete-input").val("");
                     jQuery("#addexambox .ui-autocomplete-input").text("");
                     jQuery("#listexamenprescrit").get(0).selectedIndex = 0;
+ 					changed=true;
+    			}
+            });
+            jQuery("#addmedicament").click(function () {
+                var t=jQuery("#listmedicaments").children( ":selected" ).text();
+            	if (t != "" && t != " ")
+                {
+                    var box = jQuery("#traitementprescrit");
+                    u=box.val() + (box.val() != \'\' ? "\n" : \'\') + t;
+                    box.val(u); box.html(u);
+					jQuery("#listmedicaments").get(0).selectedIndex = 0;
  					changed=true;
     			}
             });
@@ -782,6 +793,7 @@ if (! ($socid > 0)) {
 		print ajax_combobox('listmotifcons');
 		print ajax_combobox('listdiagles');
 		print ajax_combobox('listexamenprescrit');
+		print ajax_combobox('listmedicaments');
 		print ajax_combobox('banque');
 
 
@@ -962,8 +974,15 @@ if (! ($socid > 0)) {
 
 		print '</div><div class="fichehalfright"><div class="ficheaddleft">';
 
-		print $langs->trans("TraitementsPrescrits").'<br>';
-		print '<textarea name="traitementprescrit" class="flat centpercent" rows="'.($nboflines+1).'">'.$object->traitementprescrit.'</textarea><br>';
+		print $langs->trans("TraitementsPrescrits").':'.'<br>';
+		if (getDolGlobalInt('CABINETMED_SHOW_MEDICAMENTS_LIST')) {
+			print 'Medicaments :';
+			listmedicaments(1, $width, 'medicaments');
+			print ' <input type="button" class="button small" id="addmedicament" name="addmedicament" value="+">';
+		
+		}
+		if ($user->admin) print ' '.info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);		
+		print '<textarea name="traitementprescrit" id="traitementprescrit" class="flat centpercent" rows="'.($nboflines+1).'">'.$object->traitementprescrit.'</textarea><br>';
 		print $langs->trans("Infiltrations").'<br>';
 		print '<textarea name="infiltration" id="infiltration" class="flat centpercent" rows="'.ROWS_2.'">'.$object->infiltration.'</textarea><br>';
 

--- a/htdocs/cabinetmed/langs/en_US/cabinetmed.lang
+++ b/htdocs/cabinetmed/langs/en_US/cabinetmed.lang
@@ -198,3 +198,4 @@ LesionDiagnosticsGOUTTE=Gouty Arthritis
 Patients=Patients
 Consultations=Consultations
 CABINETMED_DELAY_TO_LOCK_RECORD=Consultations can't be modified x days after their creation (use 0 to keep consultations always editable) 
+CABINETMED_SHOW_MEDICAMENTS_LIST=Show medicaments list field

--- a/htdocs/cabinetmed/langs/fr_FR/cabinetmed.lang
+++ b/htdocs/cabinetmed/langs/fr_FR/cabinetmed.lang
@@ -198,3 +198,4 @@ LesionDiagnosticsGOUTTE=Gouty Arthritis
 Patients=Patients
 Consultations=Consultations
 CABINETMED_DELAY_TO_LOCK_RECORD=Les consultations ne peuvent pas être modifiées x jours après leur création (utilisez 0 pour que les consultations restent toujours modifiables)
+CABINETMED_SHOW_MEDICAMENTS_LIST=Afficher le champs liste medicaments

--- a/htdocs/cabinetmed/lib/cabinetmed.lib.php
+++ b/htdocs/cabinetmed/lib/cabinetmed.lib.php
@@ -201,6 +201,44 @@ function listexamen($nboflines, $newwidth = 0, $type = '', $showtype = 0, $htmln
 
 
 /**
+ *  Show combo box with all medicaments
+ *
+ *  @param	int		$nboflines       Max nb of lines
+ *  @param  int     $newwidth        Force width
+ *  @param  string  $type            To filter on a type (Ex: "'RADIO'" or "'RADIO','OTHER'")
+ *  @param	string	$showtype        1=Show type of line after label
+ *  @param  string	$htmlname        Name of html select area
+ *  @return	void
+ */
+function listmedicaments($nboflines, $newwidth = 0, $htmlname = 'medicaments')
+{
+	global $conf,$db,$width,$langs;
+
+	if (empty($newwidth)) $newwidth=$width;
+
+	print '<select class="flat valignmiddle maxwidth200onsmartphone" id="list'.$htmlname.'" name="list'.$htmlname.'" '.(empty($conf->dol_use_jmobile)?' style="width: '.$newwidth.'px" ':'').'size="'.$nboflines.'"'.($nboflines > 1?' multiple':'').'>';
+	print '<option value="0">&nbsp;</option>';
+
+	$sql = 'SELECT s.rowid, s.label FROM '.MAIN_DB_PREFIX.'cabinetmed_medicaments as s  WHERE active = 1 ORDER BY position, label';
+	$resql=$db->query($sql);
+	dol_syslog("medicaments sql=".$sql);
+	if ($resql) {
+		$num=$db->num_rows($resql);
+		$i=0;
+
+		while ($i < $num) {
+			$obj=$db->fetch_object($resql);
+			print '<option value="'.$obj->code.'">'.$obj->label.'</option>';
+			$i++;
+		}
+	} else {
+		dol_print_error($db);
+	}
+	print '</select>'."\n";
+}
+
+
+/**
  *  Show combo box with all exam conclusions
  *
  *  @param	int		$nboflines       Max nb of lines

--- a/htdocs/cabinetmed/sql/llx_cabinetmed_medicaments.sql
+++ b/htdocs/cabinetmed/sql/llx_cabinetmed_medicaments.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Copyright (C) 2011 Laurent Destailleur  <eldy@users.sourceforge.net>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+-- ===========================================================================
+
+CREATE TABLE llx_cabinetmed_medicaments (
+  rowid             integer AUTO_INCREMENT PRIMARY KEY,
+  code              varchar(8) NOT NULL,
+  label             varchar(64) NOT NULL,
+  active            smallint DEFAULT 1  NOT NULL,
+  position          integer DEFAULT 10,  
+  lang				varchar(12) NULL,
+) ENGINE=innodb;


### PR DESCRIPTION
Adds a new field for a list of medicaments in the consultation page.This field will allow medical professionals to add medications in prescribed treatment.
The field is optional, it can be activated and deactivated from the configuration page.
![config](https://github.com/user-attachments/assets/6a761ff1-e6e8-485c-8d58-0eaf95f8ec32)
![consultation](https://github.com/user-attachments/assets/9d5e78bd-a392-4495-ba90-7d89ac7619e8)
