### PR TITLE
Add VAT and Local Tax options to patient card

### DIFF
--- a/htdocs/cabinetmed/canvas/patient/tpl/card_edit.tpl.php
+++ b/htdocs/cabinetmed/canvas/patient/tpl/card_edit.tpl.php
@@ -521,6 +521,51 @@ if (getDolGlobalString('ACCOUNTING_FORCE_ENABLE_VAT_REVERSE_CHARGE')) {
 	print '</td></tr>';
 }
 
+
+// VAT is used
+				print '<tr><td>'.$form->editfieldkey('VATIsUsed', 'assujtva_value', '', $object, 0).'</td><td colspan="3">';
+				print '<input id="assujtva_value" name="assujtva_value" type="checkbox" ' . ($object->tva_assuj ? 'checked="checked"' : '') . ' value="1">';
+				print '</td></tr>';
+
+// Local Taxes
+				if ($mysoc->localtax1_assuj == "1" && $mysoc->localtax2_assuj == "1") {
+					print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax1IsUsed", $mysoc->country_code), 'localtax1assuj_value', '', $object, 0).'</td><td>';
+					print '<input id="localtax1assuj_value" name="localtax1assuj_value" type="checkbox" ' . ($object->localtax1_assuj ? 'checked="checked"' : '') . ' value="1">';
+					if (!isOnlyOneLocalTax(1)) {
+						print '<span class="cblt1">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(1, (float) $object->localtax1_value, "lt1");
+						print '</span>';
+					}
+					print '</td>';
+					print '</tr><tr>';
+					print '<td>'.$form->editfieldkey($langs->transcountry("LocalTax2IsUsed", $mysoc->country_code), 'localtax2assuj_value', '', $object, 0).'</td><td>';
+					print '<input id="localtax2assuj_value" name="localtax2assuj_value" type="checkbox" ' . ($object->localtax2_assuj ? 'checked="checked"' : '') . ' value="1"></td></tr>';
+					if (!isOnlyOneLocalTax(2)) {
+						print '<span class="cblt2">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(2, (float) $object->localtax2_value, "lt2");
+						print '</span>';
+					}
+					print '</td></tr>';
+				} elseif ($mysoc->localtax1_assuj == "1" && $mysoc->localtax2_assuj != "1") {
+					print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax1IsUsed", $mysoc->country_code), 'localtax1assuj_value', '', $object, 0).'</td><td colspan="3">';
+					print '<input id="localtax1assuj_value" name="localtax1assuj_value" type="checkbox" ' . ($object->localtax1_assuj ? 'checked="checked"' : '') . ' value="1">';
+					if (!isOnlyOneLocalTax(1)) {
+						print '<span class="cblt1">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(1, (float) $object->localtax1_value, "lt1");
+						print '</span>';
+					}
+					print '</td></tr>';
+				} elseif ($mysoc->localtax2_assuj == "1" && $mysoc->localtax1_assuj != "1") {
+					print '<tr><td>'.$form->editfieldkey($langs->transcountry("LocalTax2IsUsed", $mysoc->country_code), 'localtax2assuj_value', '', $object, 0).'</td><td colspan="3">';
+					print '<input id="localtax2assuj_value" name="localtax2assuj_value" type="checkbox" ' . ($object->localtax2_assuj ? 'checked="checked"' : '') . ' value="1">';
+					if (!isOnlyOneLocalTax(2)) {
+						print '<span class="cblt2">     '.$langs->transcountry("Type", $mysoc->country_code).': ';
+						$formcompany->select_localtax(2, (float) $object->localtax2_value, "lt2");
+						print '</span>';
+					}
+					print '</td></tr>';
+				}
+
 // Num secu
 print '<tr>';
 print '<td class="nowrap">'.$langs->trans('PatientVATIntra').'</td>';


### PR DESCRIPTION
I have the following issue. In Spain I need to use certain fields related to taxation with the patients in Dolibarr. The third party form actually shows those fields, but once I turn a "Third Party" into a "Patient" those fields are no longer shown and cannot be edited, seen or modified.

Let me illustrate. New Client "Third Party" (Fields are present) - See the following two screenshots:

<img width="1280" height="601" alt="image" src="https://github.com/user-attachments/assets/419af144-bb9e-4c47-b3f0-c04a96d48d7a" />

<img width="1280" height="554" alt="image" src="https://github.com/user-attachments/assets/b79741a0-a17b-421a-8a64-ad2d7eb57be8" />

Once I turn a third party into a patient those fields disappear and can no longer be edited:

<img width="1280" height="458" alt="image" src="https://github.com/user-attachments/assets/d1db3ca3-4401-41e0-935f-a7d8f18b1a6a" />

<img width="1280" height="616" alt="image" src="https://github.com/user-attachments/assets/71639848-8d11-4b71-a392-2638a7c1a324" />

This patch is intended to correct this issue. If you can propose a more elegant way to achieve the same goal, we are all ears

Thanks