### PR TITLE
Implement legal form display in card_edit.tpl.php

### DIFF
--- a/htdocs/cabinetmed/canvas/patient/tpl/card_edit.tpl.php
+++ b/htdocs/cabinetmed/canvas/patient/tpl/card_edit.tpl.php
@@ -566,6 +566,21 @@ if (getDolGlobalString('ACCOUNTING_FORCE_ENABLE_VAT_REVERSE_CHARGE')) {
 					print '</td></tr>';
 				}
 
+// Legal Form
+
+		if (!empty($conf->global->CABINETMED_SHOW_LEGAL_FORM)){
+
+				print '<tr><td>'.$form->editfieldkey('JuridicalStatus', 'forme_juridique_code', '', $object, 0).'</td>';
+				print '<td colspan="3" class="maxwidthonsmartphone">';
+				if ($object->country_id) {
+					print $formcompany->select_juridicalstatus($object->forme_juridique_code, $object->country_code, '', 'forme_juridique_code');
+				} else {
+					print $countrynotdefined;
+				}
+				print '</td></tr>';
+    	}
+
+
 // Num secu
 print '<tr>';
 print '<td class="nowrap">'.$langs->trans('PatientVATIntra').'</td>';

--- a/htdocs/cabinetmed/consultations.php
+++ b/htdocs/cabinetmed/consultations.php
@@ -1192,16 +1192,17 @@ if ($action == '' || $action == 'list' || $action == 'delete') {
 
 
 if ($action == '' || $action == 'list' || $action == 'delete') {
-	if ($soc->alert_antemed)       $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsMed"));
-	if ($soc->alert_antechirgen)   $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsChirGene"));
-	if ($soc->alert_antechirortho) $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsChirOrtho"));
-	if ($soc->alert_anterhum)      $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsRhumato"));
-	if ($soc->alert_other)         $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsMed"));
-	if ($soc->alert_traitclass)    $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("xxx"));
-	if ($soc->alert_traitallergie) $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("Allergies"));
-	if ($soc->alert_traitintol)    $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("Intolerances"));
-	if ($soc->alert_traitspec)     $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("SpecPharma"));
+	if ($soc->alert_antemed)       $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsMed"), $soc->note_antemed);
+	if ($soc->alert_antechirgen)   $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsChirGene"), $soc->note_antechirgen);
+	if ($soc->alert_antechirortho) $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsChirOrtho"), $soc->note_antechirortho);
+	if ($soc->alert_anterhum)      $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsRhumato"), $soc->note_anterhum);
+	if ($soc->alert_other)         $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("AntecedentsMed"), $soc->note_other);
+	if ($soc->alert_traitclass)    $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("xxx"), $soc->note_traitclass);
+	if ($soc->alert_traitallergie) $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("Allergies"), $soc->note_traitallergie);
+	if ($soc->alert_traitintol)    $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("Intolerances"), $soc->note_traitintol);
+	if ($soc->alert_traitspec)     $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("SpecPharma"), $soc->note_traitspec);
 	if ($soc->alert_note)          $mesgs[]=$langs->transnoentitiesnoconv("Warning").': '.$langs->transnoentitiesnoconv("AlertTriggered", $langs->transnoentitiesnoconv("Note"));
+
 
 	// Confirm delete consultation
 	if (GETPOST("action") == 'delete') {


### PR DESCRIPTION
Added legal form section to patient card edit template.

This allows us to select the correct legal form which we required in order to output invoices that can the be exported to FacturaE, which is an XML standard used by the Spanish Government to submit official invoices to public administrations.

In keeping with the wa other parts of the interface are exposed through global variables, we have created a global variable called "CABINETMED_SHOW_LEGAL_FORM" to enable or disable showing this field.

Kind regards.