### PR TITLE
Add payment terms from society to invoice

### DIFF
--- a/htdocs/cabinetmed/consultations.php
+++ b/htdocs/cabinetmed/consultations.php
@@ -1098,7 +1098,7 @@ if (! ($socid > 0)) {
 
 		// Card (CB)
 		print '<tr class="cabpaymentcarte"><td class="">';
-		print $langs->trans("PaymentTypeCarte").'</td><td>';
+		print $langs->trans("PaymentTypeCB").'</td><td>';
 		print '<input type="text" class="flat" name="montant_carte" id="idmontant_carte" value="'.($object->montant_carte != '' ? price($object->montant_carte):'').'" size="4"';
 		print ' placeholder="'.($conf->currency != $langs->getCurrencySymbol($conf->currency) ? $langs->getCurrencySymbol($conf->currency) : '').'"';
 		print '>';
@@ -1136,10 +1136,19 @@ if (! ($socid > 0)) {
 
 		// Other payment mode (VIR)
 		print '<tr class="cabpaymentthirdparty"><td class="">';
-		print $langs->trans("PaymentTypeOther").'</td><td>';
+		print $langs->trans("PaymentTypeVIR").'</td><td>';
 		print '<input type="text" class="flat" name="montant_tiers" id="idmontant_tiers" value="'.($object->montant_tiers!=''?price($object->montant_tiers):'').'" size="4"';
 		print ' placeholder="'.($conf->currency != $langs->getCurrencySymbol($conf->currency) ? $langs->getCurrencySymbol($conf->currency) : '').'"';
 		print '>';
+		if (isModEnabled("banque") and getDolGlobalString('CABINETMED_SHOW_VIR_BANK');) {
+			print ' &nbsp; ';
+			if (((float) DOL_VERSION) >= 20.0) {
+				$form->select_comptes(GETPOST('banktiersto')?GETPOST('banktiersto'):(empty($object->bank['CB']['account_id']) ? $defaultbankaccountchq : $object->bank['CB']['account_id']), 'banktiersto', 2, 'courant = 1', $langs->trans("RecBank"), '', 0, 'maxwidth200');
+			} else {
+				print $langs->trans("RecBank").' ';
+				$form->select_comptes(GETPOST('banktiersto')?GETPOST('banktiersto'):(empty($object->bank['CB']['account_id']) ? $defaultbankaccountchq : $object->bank['CB']['account_id']), 'banktiersto', 2, 'courant = 1', 1, '', 0, 'maxwidth200');
+			}
+		}
 		print '<span class="opacitymedium"> &nbsp; ('.$langs->trans("ZeroHereIfNoPayment").')</span>';
 		print '</td></tr>';
 

--- a/htdocs/cabinetmed/consultations.php
+++ b/htdocs/cabinetmed/consultations.php
@@ -1140,7 +1140,7 @@ if (! ($socid > 0)) {
 		print '<input type="text" class="flat" name="montant_tiers" id="idmontant_tiers" value="'.($object->montant_tiers!=''?price($object->montant_tiers):'').'" size="4"';
 		print ' placeholder="'.($conf->currency != $langs->getCurrencySymbol($conf->currency) ? $langs->getCurrencySymbol($conf->currency) : '').'"';
 		print '>';
-		if (isModEnabled("banque") and getDolGlobalString('CABINETMED_SHOW_VIR_BANK');) {
+		if (isModEnabled("banque") and getDolGlobalString('CABINETMED_SHOW_VIR_BANK')) {
 			print ' &nbsp; ';
 			if (((float) DOL_VERSION) >= 20.0) {
 				$form->select_comptes(GETPOST('banktiersto')?GETPOST('banktiersto'):(empty($object->bank['CB']['account_id']) ? $defaultbankaccountchq : $object->bank['CB']['account_id']), 'banktiersto', 2, 'courant = 1', $langs->trans("RecBank"), '', 0, 'maxwidth200');

--- a/htdocs/cabinetmed/consultations.php
+++ b/htdocs/cabinetmed/consultations.php
@@ -298,7 +298,12 @@ if (empty($reshook)) {
 							$invoice->socid = $soc->id;
 							$invoice->fk_soc = $soc->id;
 							$invoice->date = $datecons;
-
+                  	
+							if(getDolGlobalString('CABINETMED_FORCE_PAYMENT_TERM_FROM_SOC')){
+    							$invoice->cond_reglement_id = $soc->cond_reglement_id;
+    							$invoice->mode_reglement_id = $soc->mode_reglement_id;
+							}
+						
 							$vattouse = GETPOST('vat');
 
 							$product = new Product($db);


### PR DESCRIPTION
When generating an invoice, payment terms and methods are not included by default. I have created and would like to use the variable CABINETMED_FORCE_PAYMENT_TERM_FROM_SOC to automatically extract these details from the settings defined in the third party profile in the generated invoice so that the customer does not have to do it manually each time.

We have also changed the translation variables PaymentTypeCarte to PaymentTypeCB since what is actually done is CB (Card) and the same with PaymentTypeOther since what is really done is VIR.

Finally we have created another global variable CABINETMED_SHOW_VIR_BANK to associate the bank with the payment.

The solution provided does precisely this.






